### PR TITLE
Add pagination & filtering to Airtable MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ List all bases
 
 #### Record Operations
 - `list_records`: Retrieve records from a table
+- `list_records_full`: Retrieve all records with pagination
 - `create_record`: Add a new record
 - `update_record`: Modify an existing record
 - `delete_record`: Remove a record
@@ -141,6 +142,28 @@ Available colors for select fields:
 - `yellowBright`, `purpleBright`, `pinkBright`
 - `grayBright`, `cyanBright`, `orangeBright`
 - `blueDark1`, `greenDark1`
+
+### list_records options
+
+- `filterByFormula` - Airtable formula to filter returned records
+- `autoPaginate` - fetch all pages automatically
+- `sort` - array of `{ field, direction }`
+- `limit` - maximum number of records
+
+Example filtering by date range:
+
+```json
+{
+  "name": "list SP Kanombe May",
+  "tool": "list_records",
+  "arguments": {
+    "base_id": "app...",
+    "table_name": "Public Charging Sessions",
+    "filterByFormula": "AND({Charger Name}='SP Kanombe', DATETIME_PARSE({Date}) >= '2025-05-01', DATETIME_PARSE({Date}) <= '2025-05-31')",
+    "autoPaginate": true
+  }
+}
+```
 
 ## Contributing
 

--- a/docs/airtable.md
+++ b/docs/airtable.md
@@ -1,0 +1,23 @@
+# Airtable MCP Usage
+
+## list_records options
+
+- `filterByFormula` - Airtable formula to filter results
+- `autoPaginate` - fetch all pages until complete
+- `sort` - array of `{ field, direction }`
+- `limit` - maximum records to return
+
+## Example with date range
+
+```
+{
+  "name": "list SP Kanombe May",
+  "tool": "list_records",
+  "arguments": {
+    "base_id": "app...",
+    "table_name": "Public Charging Sessions",
+    "filterByFormula": "AND({Charger Name}='SP Kanombe', DATETIME_PARSE({Date}) >= '2025-05-01', DATETIME_PARSE({Date}) <= '2025-05-31')",
+    "autoPaginate": true
+  }
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
-  "name": "airtable-server",
-  "version": "0.1.0",
+  "name": "@felores/airtable-mcp-server",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "airtable-server",
-      "version": "0.1.0",
+      "name": "@felores/airtable-mcp-server",
+      "version": "0.4.0",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "0.6.0",
-        "axios": "^1.7.9"
+        "axios": "^1.7.9",
+        "zod": "^3.24.1"
       },
       "bin": {
         "airtable-server": "build/index.js"
@@ -17,6 +19,9 @@
       "devDependencies": {
         "@types/node": "^20.11.24",
         "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felores/airtable-mcp-server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "An Airtable Model Context Protocol Server",
   "type": "module",
   "bin": {
@@ -14,11 +14,13 @@
     "build": "tsc && node scripts/post-build.js",
     "prepare": "npm run build",
     "watch": "tsc --watch",
-    "inspector": "npx @modelcontextprotocol/inspector build/index.js"
+    "inspector": "npx @modelcontextprotocol/inspector build/index.js",
+    "dev": "node scripts/dev.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "0.6.0",
-    "axios": "^1.7.9"
+    "axios": "^1.7.9",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",

--- a/prompts/airtable.json
+++ b/prompts/airtable.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "list SP Kanombe May",
+    "tool": "list_records",
+    "arguments": {
+      "base_id": "app...",
+      "table_name": "Public Charging Sessions",
+      "filterByFormula": "AND({Charger Name}='SP Kanombe', DATETIME_PARSE({Date}) >= '2025-05-01', DATETIME_PARSE({Date}) <= '2025-05-31')",
+      "autoPaginate": true
+    }
+  }
+]

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,7 @@
+import { spawn } from 'child_process';
+
+const args = process.argv.slice(2);
+const proc = spawn('node', ['--enable-source-maps', 'build/index.js', ...args], {
+  stdio: 'inherit',
+});
+proc.on('exit', (code) => process.exit(code ?? 0));

--- a/src/airtable.ts
+++ b/src/airtable.ts
@@ -1,0 +1,95 @@
+import axios, { AxiosInstance } from "axios";
+
+export interface SortParam {
+  field: string;
+  direction: "asc" | "desc";
+}
+
+export interface ListRecordsOptions {
+  limit?: number;
+  filterByFormula?: string;
+  sort?: SortParam[];
+  autoPaginate?: boolean;
+}
+
+export class AirtableClient {
+  private axios: AxiosInstance;
+
+  constructor(apiKeyOrAxios: string | AxiosInstance) {
+    if (typeof apiKeyOrAxios === "string") {
+      this.axios = axios.create({
+        baseURL: "https://api.airtable.com/v0",
+        headers: { Authorization: `Bearer ${apiKeyOrAxios}` },
+      });
+    } else {
+      this.axios = apiKeyOrAxios;
+    }
+  }
+
+  async listRecords(
+    baseId: string,
+    tableName: string,
+    opts: ListRecordsOptions = {}
+  ): Promise<any[]> {
+    const {
+      limit,
+      filterByFormula,
+      sort,
+      autoPaginate = false,
+    } = opts;
+
+    const params: Record<string, any> = {};
+    if (limit) params.maxRecords = limit;
+    if (filterByFormula) params.filterByFormula = filterByFormula;
+    if (sort) params.sort = sort;
+
+    if (!autoPaginate) {
+      const res = await this.axios.get(`/${baseId}/${tableName}`, { params });
+      return res.data.records;
+    }
+
+    let offset: string | undefined;
+    let records: any[] = [];
+    do {
+      const res = await this.axios.get(`/${baseId}/${tableName}`, {
+        params: { ...params, offset },
+      });
+      records = records.concat(res.data.records);
+      offset = res.data.offset;
+      if (limit && records.length >= limit) {
+        records = records.slice(0, limit);
+        break;
+      }
+    } while (offset);
+
+    return records;
+  }
+}
+
+async function paginationTest() {
+  let call = 0;
+  const responses = [
+    { data: { records: [{ id: "1" }], offset: "abc" } },
+    { data: { records: [{ id: "2" }] } },
+  ];
+  const mockAxios = {
+    get: async () => responses[call++],
+  } as unknown as AxiosInstance;
+
+  const client = new AirtableClient(mockAxios);
+  const records = await client.listRecords("base", "table", { autoPaginate: true });
+  if (records.length !== 2) {
+    throw new Error("Pagination test failed");
+  }
+  console.log("Pagination test passed");
+}
+
+if (
+  process.argv[1] &&
+  (process.argv[1].endsWith("airtable.ts") || process.argv[1].endsWith("airtable.js"))
+) {
+  paginationTest().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import axios, { AxiosInstance } from "axios";
 import { FieldOption, fieldRequiresOptions, getDefaultOptions, FieldType } from "./types.js";
+import { AirtableClient } from "./airtable.js";
+import { ListRecordsArgumentsSchema } from "./schema.js";
 
 const API_KEY = process.env.AIRTABLE_API_KEY;
 if (!API_KEY) {
@@ -19,12 +21,13 @@ if (!API_KEY) {
 class AirtableServer {
   private server: Server;
   private axiosInstance: AxiosInstance;
+  private airtable: AirtableClient;
 
   constructor() {
     this.server = new Server(
       {
         name: "airtable-server",
-        version: "0.2.0",
+        version: "0.4.0",
       },
       {
         capabilities: {
@@ -39,6 +42,7 @@ class AirtableServer {
         Authorization: `Bearer ${API_KEY}`,
       },
     });
+    this.airtable = new AirtableClient(this.axiosInstance);
 
     this.setupToolHandlers();
     
@@ -264,7 +268,59 @@ class AirtableServer {
                 type: "string",
                 description: "Name of the table",
               },
-              max_records: {
+              limit: {
+                type: "number",
+                description: "Maximum number of records to return",
+              },
+              filterByFormula: {
+                type: "string",
+                description: "Formula to filter records",
+              },
+              autoPaginate: {
+                type: "boolean",
+                description: "Fetch all pages automatically",
+              },
+              sort: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    field: { type: "string" },
+                    direction: { type: "string", enum: ["asc", "desc"] },
+                  },
+                  required: ["field", "direction"],
+                },
+                description: "Sorting parameters",
+              },
+            },
+            required: ["base_id", "table_name"],
+          },
+        },
+        {
+          name: "list_records_full",
+          description: "List all records in a table with pagination",
+          inputSchema: {
+            type: "object",
+            properties: {
+              base_id: { type: "string", description: "ID of the base" },
+              table_name: { type: "string", description: "Name of the table" },
+              filterByFormula: {
+                type: "string",
+                description: "Formula to filter records",
+              },
+              sort: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    field: { type: "string" },
+                    direction: { type: "string", enum: ["asc", "desc"] },
+                  },
+                  required: ["field", "direction"],
+                },
+                description: "Sorting parameters",
+              },
+              limit: {
                 type: "number",
                 description: "Maximum number of records to return",
               },
@@ -508,19 +564,36 @@ class AirtableServer {
           }
 
           case "list_records": {
-            const { base_id, table_name, max_records } = request.params.arguments as {
-              base_id: string;
-              table_name: string;
-              max_records?: number;
-            };
-            const response = await this.axiosInstance.get(`/${base_id}/${table_name}`, {
-              params: max_records ? { maxRecords: max_records } : undefined,
+            const args = ListRecordsArgumentsSchema.parse(
+              request.params.arguments
+            );
+            const records = await this.airtable.listRecords(args.base_id, args.table_name, {
+              limit: args.limit,
+              filterByFormula: args.filterByFormula,
+              sort: args.sort,
+              autoPaginate: args.autoPaginate,
             });
             return {
-              content: [{
-                type: "text",
-                text: JSON.stringify(response.data.records, null, 2),
-              }],
+              content: [
+                { type: "text", text: JSON.stringify(records, null, 2) },
+              ],
+            };
+          }
+
+          case "list_records_full": {
+            const args = ListRecordsArgumentsSchema.parse(
+              request.params.arguments
+            );
+            const records = await this.airtable.listRecords(args.base_id, args.table_name, {
+              limit: args.limit,
+              filterByFormula: args.filterByFormula,
+              sort: args.sort,
+              autoPaginate: true,
+            });
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(records, null, 2) },
+              ],
             };
           }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const ListRecordsArgumentsSchema = z.object({
+  base_id: z.string(),
+  table_name: z.string(),
+  limit: z.number().int().positive().optional(),
+  filterByFormula: z.string().optional(),
+  autoPaginate: z.boolean().optional(),
+  sort: z
+    .array(
+      z.object({
+        field: z.string(),
+        direction: z.enum(["asc", "desc"]),
+      })
+    )
+    .optional(),
+});
+
+export type ListRecordsArguments = z.infer<typeof ListRecordsArgumentsSchema>;


### PR DESCRIPTION
## Summary
- add Airtable client helper with pagination
- validate list_records arguments with zod
- support `autoPaginate` and `filterByFormula`
- add new command `list_records_full`
- provide docs and example JSON
- bump version to 0.4.0 and add dev script

## Testing
- `npm run build`
- `node build/airtable.js`

------
https://chatgpt.com/codex/tasks/task_e_6854064c71dc8328a9a7cb6685bf3342